### PR TITLE
feat: increase branch coverage in `BinaryHeapArray.validateNode`

### DIFF
--- a/src/com/jwetherell/algorithms/data_structures/BinaryHeap.java
+++ b/src/com/jwetherell/algorithms/data_structures/BinaryHeap.java
@@ -107,6 +107,16 @@ public interface BinaryHeap<T extends Comparable<T>> extends IHeap<T> {
         }
 
         /**
+         * Create a heap from an already "heapified" array.
+         * If this is not the case (ie. the array is in arbitrary order, behaviour is undefined).
+         * @param items The heapified array
+         */
+        public void setArrayUnsafe(T[] items) {
+            this.size = items.length;
+            this.array = Arrays.copyOf(items, Integer.max(items.length, MINIMUM_SIZE));
+        }
+
+        /**
          * {@inheritDoc}
          */
         @Override

--- a/test/com/jwetherell/algorithms/data_structures/test/BinaryHeapTests.java
+++ b/test/com/jwetherell/algorithms/data_structures/test/BinaryHeapTests.java
@@ -1,6 +1,7 @@
 package com.jwetherell.algorithms.data_structures.test;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
 import java.util.Collection;
@@ -80,5 +81,31 @@ public class BinaryHeapTests {
         tHeapNull.add(11);
         tHeapNull.clear();
         assertNull(tHeapNull.getHeadValue()); // we expect null here
+    }
+
+    @Test
+    public void testValidateNodeValid() {
+        BinaryHeap.BinaryHeapArray<Integer> heap = new BinaryHeap.BinaryHeapArray<Integer>(BinaryHeap.Type.MAX);
+        heap.setArrayUnsafe(new Integer[]{ 3, 2, 1 });
+        assertTrue(heap.validate());
+    }
+
+    // Improves branch coverage in `validateNode` from 57.7% to 65.4%
+    @Test
+    public void testValidateNodeMaxInvalidLeft() {
+        BinaryHeap.BinaryHeapArray<Integer> heap = new BinaryHeap.BinaryHeapArray<Integer>(BinaryHeap.Type.MAX);
+
+        // An invalid heap (wrong ordering) should be flagged as invalid
+        heap.setArrayUnsafe(new Integer[]{ 3, 4, 1 });
+        assertFalse(heap.validate());
+    }
+
+    // Improves branch coverage in `validateNode` from 65.4% to 81.2%
+    @Test
+    public void testValidateNodeMaxInvalidRight() {
+        BinaryHeap.BinaryHeapArray<Integer> heap = new BinaryHeap.BinaryHeapArray<Integer>(BinaryHeap.Type.MAX);
+        // Check that invalid order is checked for right child as well
+        heap.setArrayUnsafe(new Integer[]{ 3, 2, 4 });
+        assertFalse(heap.validate());
     }
 }


### PR DESCRIPTION
part of #40. Adds 3 additional test cases. We also need to include a way to construct a heap directly from an array (in order to create a heap in an invalid state).